### PR TITLE
v1 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,14 +14,22 @@ This change was validated by the following observations:
 
 ## Checklist
 
+General:
+
 - [ ] I have deployed and validated this change
 
 - [ ] Changelog
   - [ ] I have added my changes to CHANGELOG.md
   - [ ] No changelog entry is necessary
 
+Version release: 
+
+- [ ] In CHANGELOG.md, I have moved unreleased items to a newly created release section
+
 If a new input variable was added:
+
 - [ ] I have added a new variable in inputs.tf with a description, added the variable to defaults.tfvars, and to ./utils/cicd/main.tf
 
 If the built-in stac-server version was updated:
+
 - [ ] I have updated the `stac_server_version` default value in inputs.tf, noted a version bump in CHANGELOG.md, updated the `STAC_SERVER_TAG` throughout ./.github/workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-- Support inputs.stac_server_version usage
-
 ### Added
 
 ### Changed
@@ -16,6 +14,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 ### Removed
+
+## [1.0.0] - 2025-10-30
+
+### Added
+
+- Support inputs.stac_server_version usage
+
+- CICD setup
 
 ## [0.0.1] - 2025-10-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@
 
 **Updating the Default, Built-In stac-server Version**
 
-We prepackage a specific stac-server version with each release of this repository. To change this prepackaged version:
+We package a specific stac-server version with each release of this repository. To change this packaged version:
 
 1. Build stac-server and get its lambdas: `./utils/update-lambdas.bash v3.10.0`
 
-2. *Important* -- follow the steps in the PR template to note and propagate the change to appropriate files
+2. *Important* -- follow the steps in `.github/pull_request_template.md` to note and propagate the change to appropriate files


### PR DESCRIPTION
## Related issue(s)

- NA

## Proposed Changes

- Release v1

## Testing

This change was validated by the following observations:

-  NA

## Checklist

- [ ] I have deployed and validated this change

- [x] Changelog
  - [x] I have added my changes to CHANGELOG.md
  - [ ] No changelog entry is necessary

If a new input variable was added:
- [ ] I have added a new variable in inputs.tf with a description, added the variable to defaults.tfvars, and to ./utils/cicd/main.tf

If the built-in stac-server version was updated:
- [ ] I have updated the `stac_server_version` default value in inputs.tf, noted a version bump in CHANGELOG.md, updated the `STAC_SERVER_TAG` throughout ./.github/workflows
