### PR TITLE
chore: API gateway dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ We would love for you to contribute! Follow the steps below to get started, and 
 
 **Prerequisites**
 
-- An AWS account with an existing VPC, that contains at least one private subnet
+- A VPC in an AWS account which contains at least one private subnet
+- In the AWS region you're deploying to, in API Gateway a [CloudWatch log role ARN](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions) set
 
 **Setup**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ We would love for you to contribute! Follow the steps below to get started, and 
 **Prerequisites**
 
 - A VPC in an AWS account which contains at least one private subnet
-- In the AWS region you're deploying to, in API Gateway a [CloudWatch log role ARN](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions) set
 
 **Setup**
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ A default version of stac-server is packaged with this module. See the default v
 While this module is most commonly used in conjunction with a FilmDrop deployment, it can be deployed as a standalone STAC server. Prerequisites:
 
 - A VPC in an AWS account which contains at least one private subnet
-- In the AWS region you're deploying to, in API Gateway a [CloudWatch log role ARN](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions) set
 
 **Quickstart**
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ A default version of stac-server is packaged with this module. See the default v
 
 ## General Usage
 
-While this module is most commonly used in conjunction with a FilmDrop deployment, it can be deployed as a standalone STAC server. As a prerequisite, a VPC in an AWS account which contains at least one private subnet will be needed.
+While this module is most commonly used in conjunction with a FilmDrop deployment, it can be deployed as a standalone STAC server. Prerequisites:
+
+- A VPC in an AWS account which contains at least one private subnet
+- In the AWS region you're deploying to, in API Gateway a [CloudWatch log role ARN](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions) set
 
 **Quickstart**
 

--- a/api.tf
+++ b/api.tf
@@ -286,6 +286,12 @@ resource "aws_api_gateway_deployment" "stac_server_api_gateway" {
   depends_on = [
     aws_api_gateway_integration.stac_server_api_gateway_root_method_integration,
     aws_api_gateway_integration.stac_server_api_gateway_proxy_resource_method_integration,
+    aws_api_gateway_method_response.stac_root_options_200,
+    aws_api_gateway_method_response.stac_options_200,
+    aws_api_gateway_integration.stac_root_options_integration,
+    aws_api_gateway_integration.stac_options_integration,
+    aws_api_gateway_integration_response.stac_root_options_integration_response,
+    aws_api_gateway_integration_response.stac_options_integration_response,
   ]
 
   rest_api_id = aws_api_gateway_rest_api.stac_server_api_gateway.id
@@ -379,5 +385,5 @@ resource "aws_api_gateway_base_path_mapping" "stac_server_api_gateway_domain_map
   domain_name    = aws_api_gateway_domain_name.stac_server_api_gateway_domain_name[0].domain_name
   domain_name_id = aws_api_gateway_domain_name.stac_server_api_gateway_domain_name[0].domain_name_id
   api_id         = aws_api_gateway_rest_api.stac_server_api_gateway.id
-  stage_name     = var.stac_api_stage
+  stage_name     = aws_api_gateway_stage.stac_server_api_gateway_stage.stage_name
 }


### PR DESCRIPTION
## Related issue(s)

- NA

## Proposed Changes

- Adds API Gateway dependencies so that changes to those dependencies trigger a redeploy of the gateway stage. Without this, changes to these dependencies are not applied until a future changes forces a redeployment of the gateway stage

## Testing

This change was validated by the following observations:

-  With an existing deployment, ensured this was not a breaking change

## Checklist

**General**
- [x] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to CHANGELOG.md
  - [x] No changelog entry is necessary

**If releasing a new version**
- [ ] In CHANGELOG.md, I have moved unreleased items to a newly created release section

**If a new input variable was added**
- [ ] I have added a new variable in inputs.tf with a description, added the variable to defaults.tfvars, and to ./utils/cicd/main.tf

**If the built-in stac-server version was updated**
- [ ] I have updated the `stac_server_version` default value in inputs.tf, noted a version bump in CHANGELOG.md, and updated the `STAC_SERVER_TAG` throughout ./.github/workflows

`🤖 with assistance from our AI Overlords 🤖`