### PR TITLE
chore: deprecated runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Lambda runtimes for the `user_init` and `historical_ingest` updated from python v3.9, which is beyond deprecation, to v3.10
+
 ### Added
 
 ### Changed

--- a/modules/historical-ingest/lambda.tf
+++ b/modules/historical-ingest/lambda.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_function" "historical_ingest" {
   description   = "Historical Ingest Lambda"
   role          = var.stac_server_lambda_iam_role_arn
   handler       = "main.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.10"
   timeout       = 900
   memory_size   = 1536
 

--- a/opensearch_domain.tf
+++ b/opensearch_domain.tf
@@ -259,7 +259,7 @@ resource "aws_lambda_function" "stac_server_opensearch_user_initializer" {
   role             = aws_iam_role.stac_api_lambda_role.arn
   description      = "Lambda function to initialize OpenSearch users, roles, and settings."
   handler          = "main.lambda_handler"
-  runtime          = "python3.9"
+  runtime          = "python3.10"
   memory_size      = "512"
   timeout          = "900"
 


### PR DESCRIPTION
## Related issue(s)

- NA

## Proposed Changes

- Lambda no longer supports lambda python v3.9

## Testing

This change was validated by the following observations:

-  NA. Deployments seem to work fine, but there is currently no way to test the `stac_server_opensearch_user_initializer` function other than "deploy it and see if things seem to have worked"

## Checklist

**General**
- [ ] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to CHANGELOG.md
  - [ ] No changelog entry is necessary

**If releasing a new version**
- [ ] In CHANGELOG.md, I have moved unreleased items to a newly created release section

**If a new input variable was added**
- [ ] I have added a new variable in inputs.tf with a description, added the variable to defaults.tfvars, and to ./utils/cicd/main.tf

**If the built-in stac-server version was updated**
- [ ] I have updated the `stac_server_version` default value in inputs.tf, noted a version bump in CHANGELOG.md, and updated the `STAC_SERVER_TAG` throughout ./.github/workflows
