### PR TITLE
fix: api gateway point to lambda published version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
+## [2.0.3] - 2026-01-27
+
+### Fixed
+
+- Correctly point API Gateway to the published lambda version so that features like provisioned concurrency work as expected, and trigger deployment of the gateway when any changes to dependencies occur
 
 ## [2.0.2] - 2026-01-26
 

--- a/api.tf
+++ b/api.tf
@@ -189,7 +189,7 @@ resource "aws_api_gateway_integration" "stac_server_api_gateway_root_method_inte
   resource_id             = aws_api_gateway_rest_api.stac_server_api_gateway.root_resource_id
   http_method             = aws_api_gateway_method.stac_server_api_gateway_root_method.http_method
   type                    = "AWS_PROXY"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.stac_server_api.arn}/invocations"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.stac_server_api.qualified_arn}/invocations"
   integration_http_method = "POST"
 }
 
@@ -287,7 +287,7 @@ resource "aws_api_gateway_integration" "stac_server_api_gateway_proxy_resource_m
   resource_id             = aws_api_gateway_resource.stac_server_api_gateway_proxy_resource.id
   http_method             = aws_api_gateway_method.stac_server_api_gateway_proxy_resource_method.http_method
   type                    = "AWS_PROXY"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.stac_server_api.arn}/invocations"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.stac_server_api.qualified_arn}/invocations"
   integration_http_method = "POST"
 }
 
@@ -304,6 +304,24 @@ resource "aws_api_gateway_deployment" "stac_server_api_gateway" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.stac_server_api_gateway.id
+
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_resource.stac_server_api_gateway_proxy_resource,
+      aws_api_gateway_method.stac_server_api_gateway_root_method,
+      aws_api_gateway_integration.stac_server_api_gateway_root_method_integration,
+      aws_api_gateway_method.stac_server_api_gateway_proxy_resource_method,
+      aws_api_gateway_integration.stac_server_api_gateway_proxy_resource_method_integration,
+      aws_api_gateway_method.stac_root_options_method,
+      aws_api_gateway_method_response.stac_root_options_200,
+      aws_api_gateway_integration.stac_root_options_integration,
+      aws_api_gateway_integration_response.stac_root_options_integration_response,
+      aws_api_gateway_method.stac_options_method,
+      aws_api_gateway_method_response.stac_options_200,
+      aws_api_gateway_integration.stac_options_integration,
+      aws_api_gateway_integration_response.stac_options_integration_response,
+    ]))
+  }
 
   lifecycle {
     create_before_destroy = true
@@ -333,6 +351,7 @@ resource "aws_lambda_permission" "stac_server_api_gateway_lambda_permission_root
   statement_id  = "AllowExecutionFromAPIGatewayRootResource"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.stac_server_api.arn
+  qualifier     = aws_lambda_function.stac_server_api.version
   principal     = "apigateway.amazonaws.com"
 
   source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.stac_server_api_gateway.id}/*/*"
@@ -342,6 +361,7 @@ resource "aws_lambda_permission" "stac_server_api_gateway_lambda_permission_prox
   statement_id  = "AllowExecutionFromAPIGatewayProxyResource"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.stac_server_api.arn
+  qualifier     = aws_lambda_function.stac_server_api.version
   principal     = "apigateway.amazonaws.com"
 
   source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.stac_server_api_gateway.id}/*/*${aws_api_gateway_resource.stac_server_api_gateway_proxy_resource.path}"


### PR DESCRIPTION
## Related issue(s)

- 

## Proposed Changes

- Have api gateway point to the published version of the api lambda (otherwise things like provisioned concurrency do not work)
- List all deps of the gateway in a triggers block so that changes to them force a redeploy of the gateway stage

## Testing

This change was validated by the following observations:

-  terraform validate

## Checklist

**General**
- [x] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to CHANGELOG.md
  - [ ] No changelog entry is necessary

**If releasing a new version**
- [x] In CHANGELOG.md, I have moved unreleased items to a newly created release section

**If a new input variable was added**
- [ ] I have added a new variable in inputs.tf with a description, added the variable to defaults.tfvars, and to ./utils/cicd/main.tf

**If the built-in stac-server version was updated**
- [ ] I have updated the `stac_server_version` default value in inputs.tf, noted a version bump in CHANGELOG.md, and updated the `STAC_SERVER_TAG` throughout ./.github/workflows
