### PR TITLE
fix(api): add request_templates to OPTIONS MOCK integrations

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -230,6 +230,9 @@ resource "aws_api_gateway_integration" "stac_root_options_integration" {
   resource_id = aws_api_gateway_rest_api.stac_server_api_gateway.root_resource_id
   http_method = aws_api_gateway_method.stac_root_options_method.http_method
   type        = "MOCK"
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
 }
 
 resource "aws_api_gateway_integration_response" "stac_root_options_integration_response" {
@@ -268,6 +271,9 @@ resource "aws_api_gateway_integration" "stac_options_integration" {
   resource_id = aws_api_gateway_resource.stac_server_api_gateway_proxy_resource.id
   http_method = aws_api_gateway_method.stac_options_method.http_method
   type        = "MOCK"
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
 }
 
 resource "aws_api_gateway_integration_response" "stac_options_integration_response" {


### PR DESCRIPTION
## Summary
The OPTIONS method on both `/` and `/{proxy+}` is wired to a MOCK integration, but neither integration declares `request_templates`. AWS API Gateway needs a request template that returns a `statusCode` for the gateway to know what method response to map back to the client. Without it, every OPTIONS request returns:

```
HTTP/2 500
x-amzn-errortype: InternalServerErrorException
```

This breaks browser CORS preflight on any cross-origin client (e.g. a SPA hitting the STAC API directly). The actual `GET`/`POST` handlers emit the correct CORS headers, but browsers cancel the request because the preflight failed first. Calling the API directly with `curl` works, which makes this easy to miss until a real browser client hits it.

## Fix
Add the standard `request_templates` block to both `aws_api_gateway_integration` MOCK resources for OPTIONS:

```hcl
request_templates = {
  "application/json" = "{\"statusCode\": 200}"
}
```

That's the minimum AWS needs for a MOCK integration to map to a `200` integration response (which already exists in `stac_root_options_integration_response` / `stac_options_integration_response` and carries the CORS headers).

## Notes
- Putting CloudFront in front of the API (e.g. via `deploy_cloudfront = true` in downstream wrappers) can mask this bug because the CDN handles CORS preflight at the edge — but the underlying API Gateway is still broken, and any consumer that hits the API Gateway URL directly will trip over it. This change fixes the root cause.
- No behavior change for non-OPTIONS methods, no new variables, no breaking interface changes.

## How I verified
Reproduced against a v2.0.3 deployment:

```
$ curl -sI -X OPTIONS \
    "https://<id>.execute-api.us-west-2.amazonaws.com/dev/collections" \
    -H "Origin: https://example.com" \
    -H "Access-Control-Request-Method: GET"
HTTP/2 500
x-amzn-errortype: InternalServerErrorException
```

After applying this patch in a fork and updating downstream module pins, the same OPTIONS request returns `200` with the expected `Access-Control-Allow-*` headers, and browser-driven calls to `/collections` succeed.